### PR TITLE
Remove hardcoded security group identifiers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -92,7 +92,6 @@ resource "aws_vpc_endpoint" "s3" {
 #
 
 resource "aws_security_group" "nat" {
-  name = "nat-security-group"
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {
@@ -149,7 +148,6 @@ resource "aws_instance" "nat" {
 #
 
 resource "aws_security_group" "bastion" {
-  name = "bastion-security-group"
   vpc_id = "${aws_vpc.default.id}"
 
   ingress {


### PR DESCRIPTION
Attempt to remove hardcoded security group names from the module so that multiple instances of resources can exist within the same AWS account.