### PR TITLE
Add create_before_destroy to subnet resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,8 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_subnet" "private" {
+  lifecycle { create_before_destroy = true }
+
   count = "${length(split(",", var.private_subnet_cidr_blocks))}"
 
   vpc_id = "${aws_vpc.default.id}"
@@ -55,6 +57,8 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_subnet" "public" {
+  lifecycle { create_before_destroy = true }
+
   count = "${length(split(",", var.public_subnet_cidr_blocks))}"
 
   vpc_id = "${aws_vpc.default.id}"


### PR DESCRIPTION
The story behind this change is long and convoluted.

In order to complete the trick outlined below that cycles in instances created by a new ASG before terminating the old:

  https://groups.google.com/d/msg/terraform-tool/7Gdhv1OAc80/iNQ93riiLwAJ

The `create_before_destroy` lifecycle attribute has to be set to `true` on all resources up the dependency chain of the ASG and its associated launch configuration.

For an ASG resource, the `vpc_zone_identifier` hold references to VPC subnet IDs, which means the associated subnet resources also need the `create_before_destroy` attribute enabled.

For more detail, see: https://github.com/hashicorp/terraform/issues/2359