### PR TITLE
Output `nat_security_group_id` so additional rules can be added

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,5 @@ module "vpc" {
 - `public_subnet_ids` - List of public subnet IDs
 - `private_subnets_ids` - List of private subnet IDs
 - `bastion_hostname` - Public DNS name for bastion instance
+- `nat_security_group_id` - ID of the security group for the NAT instance
+- `cidr_block` - The CIDR block associated with the VPC

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ module "vpc" {
   availability_zones = "us-east-1a,us-east-1b"
   nat_ami = "ami-303b1458"
   nat_instance_type = "t2.micro"
+  nat_egress_ports = "22,80,443,587"
   bastion_ami = "ami-ff02509a"
   bastion_instance_type = "t2.micro"
 }
@@ -36,6 +37,7 @@ module "vpc" {
 - `availability_zones` - Comma delimited list of availability zones (default: `us-east-1a,us-east-1b`)
 - `nat_ami` - NAT Amazon Machine Image (AMI) ID
 - `nat_instance_type` - Instance type for NAT instance (default: `t2.micro`))
+- `nat_egress_ports` - Ports to open on the NAT instance for connecting out to the internet (default: `80,443`)
 - `bastion_ami` - Bastion Amazon Machine Image (AMI) ID
 - `bastion_instance_type` - Instance type for bastion instance (default: `t2.micro`))
 

--- a/main.tf
+++ b/main.tf
@@ -104,37 +104,37 @@ resource "aws_vpc_endpoint" "s3" {
 resource "aws_security_group" "nat" {
   vpc_id = "${aws_vpc.default.id}"
 
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["${aws_vpc.default.cidr_block}"]
-  }
-
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["${aws_vpc.default.cidr_block}"]
-  }
-
-  egress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   tags {
     Name = "sgNAT"
   }
+}
+
+resource "aws_security_group_rule" "allow_port_ingress" {
+  count = "${length(split(",", var.nat_egress_ports))}"
+
+  type = "ingress"
+
+  cidr_blocks = ["${var.cidr_block}"]
+  from_port = "${element(split(",", var.nat_egress_ports), count.index)}"
+  to_port = "${element(split(",", var.nat_egress_ports), count.index)}"
+
+  protocol = "tcp"
+
+  security_group_id = "${aws_security_group.nat.id}"
+}
+
+resource "aws_security_group_rule" "allow_port_egress" {
+  count = "${length(split(",", var.nat_egress_ports))}"
+
+  type = "egress"
+
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port = "${element(split(",", var.nat_egress_ports), count.index)}"
+  to_port = "${element(split(",", var.nat_egress_ports), count.index)}"
+
+  protocol = "tcp"
+
+  security_group_id = "${aws_security_group.nat.id}"
 }
 
 resource "aws_instance" "nat" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,11 @@ output "private_subnet_ids" {
 output "bastion_hostname" {
   value = "${aws_instance.bastion.public_dns}"
 }
+
+output "nat_security_group_id" {
+  value = "${aws_security_group.nat.id}"
+}
+
+output "cidr_block" {
+  value = "${var.cidr_block}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,10 @@ variable "nat_instance_type" {
   default = "t2.micro"
 }
 
+variable "nat_egress_ports" {
+  default = "80,443"
+}
+
 variable "bastion_ami" {
 }
 


### PR DESCRIPTION
This is so terraform configurations that call this module can add extra rules to the NAT security group.

@notthatbreezy FYI