### PR TITLE
Emit bastion security group ID; use security group rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,5 @@ module "vpc" {
 - `public_subnet_ids` - List of public subnet IDs
 - `private_subnets_ids` - List of private subnet IDs
 - `bastion_hostname` - Public DNS name for bastion instance
+- `bastion_security_group_id` - Security group ID tied to bastion instance
 - `cidr_block` - The CIDR block associated with the VPC

--- a/main.tf
+++ b/main.tf
@@ -123,37 +123,45 @@ resource "aws_nat_gateway" "default" {
 resource "aws_security_group" "bastion" {
   vpc_id = "${aws_vpc.default.id}"
 
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["${var.external_access_cidr_block}"]
-  }
-
-  egress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["${aws_vpc.default.cidr_block}"]
-  }
-
-  egress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   tags {
     Name = "sgBastion"
   }
+}
+
+resource "aws_security_group_rule" "bastion_ssh_ingress" {
+  type = "ingress"
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  cidr_blocks = ["${var.external_access_cidr_block}"]
+  security_group_id = "${aws_security_group.bastion.id}"
+}
+
+resource "aws_security_group_rule" "bastion_ssh_egress" {
+  type = "egress"
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.bastion.id}"
+}
+
+resource "aws_security_group_rule" "bastion_http_egress" {
+  type = "egress"
+  from_port = 80
+  to_port = 80
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.bastion.id}"
+}
+
+resource "aws_security_group_rule" "bastion_https_egress" {
+  type = "egress"
+  from_port = 443
+  to_port = 443
+  protocol = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.bastion.id}"
 }
 
 resource "aws_instance" "bastion" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,10 @@ output "bastion_hostname" {
   value = "${aws_instance.bastion.public_dns}"
 }
 
+output "bastion_security_group_id" {
+  value = "${aws_security_group.bastion.id}"
+}
+
 output "cidr_block" {
   value = "${var.cidr_block}"
 }


### PR DESCRIPTION
Introduce more flexibility to the bastion's security group rules so that they can be extended, or referenced from another security group by ID.