### PR TITLE
Add public and private route tables to S3 VPC endpoint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "aws_route_table_association" "public" {
 resource "aws_vpc_endpoint" "s3" {
   vpc_id          = "${aws_vpc.default.id}"
   service_name    = "com.amazonaws.${var.region}.s3"
-  route_table_ids = ["${aws_route_table.public.id}"]
+  route_table_ids = ["${aws_route_table.public.id}", "${aws_route_table.private.*.id}"]
 }
 
 #


### PR DESCRIPTION
Previously, only the public route table was being added to the S3 VPC endpoint. Now both the public and private route tables are being added.