### PR TITLE
Remove security group rules and create_before_destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,17 @@ module "vpc" {
   availability_zones = "us-east-1a,us-east-1b"
   bastion_ami = "ami-ff02509a"
   bastion_instance_type = "t2.micro"
+
+  project = "Something"
+  environment = "Staging"
 }
 ```
 
 ## Variables
 
 - `name` - Name of the VPC (default: `Default`)
+- `project` - Name of project this VPC is meant to house (default: `Unknown`)
+- `environment` - Name of environment this VPC is targeting (default: `Unknown`)
 - `region` - Region of the VPC (default: `us-east-1`)
 - `key_name` - EC2 Key pair name
 - `cidr_block` - CIDR block to allocate for the VPC (default: `10.0.0.0/16`)

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,9 @@ resource "aws_vpc" "default" {
   enable_dns_hostnames = true
 
   tags {
-    Name = "${var.name}"
+    Name        = "${var.name}"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
   }
 }
 
@@ -27,7 +29,9 @@ resource "aws_route_table" "private" {
   }
 
   tags {
-    Name = "PrivateRouteTable"
+    Name        = "PrivateRouteTable"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
   }
 }
 
@@ -40,7 +44,9 @@ resource "aws_route_table" "public" {
   }
 
   tags {
-    Name = "PublicRouteTable"
+    Name        = "PublicRouteTable"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
   }
 }
 
@@ -52,7 +58,9 @@ resource "aws_subnet" "private" {
   availability_zone = "${element(split(",", var.availability_zones), count.index)}"
 
   tags {
-    Name = "PrivateSubnet"
+    Name        = "PrivateSubnet"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
   }
 }
 
@@ -65,7 +73,9 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = true
 
   tags {
-    Name = "PublicSubnet"
+    Name        = "PublicSubnet"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
   }
 }
 
@@ -116,7 +126,9 @@ resource "aws_security_group" "bastion" {
   vpc_id = "${aws_vpc.default.id}"
 
   tags {
-    Name = "sgBastion"
+    Name        = "sgBastion"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
   }
 }
 
@@ -167,6 +179,8 @@ resource "aws_instance" "bastion" {
   associate_public_ip_address = true
 
   tags {
-    Name = "Bastion"
+    Name        = "Bastion"
+    Project     = "${var.project}"
+    Environment = "${var.environment}"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -132,42 +132,6 @@ resource "aws_security_group" "bastion" {
   }
 }
 
-resource "aws_security_group_rule" "bastion_ssh_ingress" {
-  type              = "ingress"
-  from_port         = 22
-  to_port           = 22
-  protocol          = "tcp"
-  cidr_blocks       = ["${var.external_access_cidr_block}"]
-  security_group_id = "${aws_security_group.bastion.id}"
-}
-
-resource "aws_security_group_rule" "bastion_ssh_egress" {
-  type              = "egress"
-  from_port         = 22
-  to_port           = 22
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.bastion.id}"
-}
-
-resource "aws_security_group_rule" "bastion_http_egress" {
-  type              = "egress"
-  from_port         = 80
-  to_port           = 80
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.bastion.id}"
-}
-
-resource "aws_security_group_rule" "bastion_https_egress" {
-  type              = "egress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.bastion.id}"
-}
-
 resource "aws_instance" "bastion" {
   ami                         = "${var.bastion_ami}"
   availability_zone           = "${element(split(",", var.availability_zones), 0)}"

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "aws_route_table" "private" {
   vpc_id = "${aws_vpc.default.id}"
 
   route {
-    cidr_block  = "0.0.0.0/0"
+    cidr_block     = "0.0.0.0/0"
     nat_gateway_id = "${element(aws_nat_gateway.default.*.id, count.index)}"
   }
 
@@ -45,10 +45,6 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_subnet" "private" {
-  lifecycle {
-    create_before_destroy = true
-  }
-
   count = "${length(split(",", var.private_subnet_cidr_blocks))}"
 
   vpc_id            = "${aws_vpc.default.id}"
@@ -61,10 +57,6 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_subnet" "public" {
-  lifecycle {
-    create_before_destroy = true
-  }
-
   count = "${length(split(",", var.public_subnet_cidr_blocks))}"
 
   vpc_id                  = "${aws_vpc.default.id}"
@@ -111,7 +103,7 @@ resource "aws_nat_gateway" "default" {
   count = "${length(split(",", var.public_subnet_cidr_blocks))}"
 
   allocation_id = "${element(aws_eip.nat.*.id, count.index)}"
-  subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
+  subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
 
   depends_on = ["aws_internet_gateway.default"]
 }
@@ -129,38 +121,38 @@ resource "aws_security_group" "bastion" {
 }
 
 resource "aws_security_group_rule" "bastion_ssh_ingress" {
-  type = "ingress"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["${var.external_access_cidr_block}"]
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.external_access_cidr_block}"]
   security_group_id = "${aws_security_group.bastion.id}"
 }
 
 resource "aws_security_group_rule" "bastion_ssh_egress" {
-  type = "egress"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  type              = "egress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.bastion.id}"
 }
 
 resource "aws_security_group_rule" "bastion_http_egress" {
-  type = "egress"
-  from_port = 80
-  to_port = 80
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  type              = "egress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.bastion.id}"
 }
 
 resource "aws_security_group_rule" "bastion_https_egress" {
-  type = "egress"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.bastion.id}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -6,8 +6,7 @@ variable "region" {
   default = "us-east-1"
 }
 
-variable "key_name" {
-}
+variable "key_name" {}
 
 variable "cidr_block" {
   default = "10.0.0.0/16"
@@ -29,8 +28,7 @@ variable "availability_zones" {
   default = "us-east-1a,us-east-1b"
 }
 
-variable "bastion_ami" {
-}
+variable "bastion_ami" {}
 
 variable "bastion_instance_type" {
   default = "t2.micro"

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,14 @@ variable "name" {
   default = "Default"
 }
 
+variable "project" {
+  default = "Unknown"
+}
+
+variable "environment" {
+  default = "Unknown"
+}
+
 variable "region" {
   default = "us-east-1"
 }


### PR DESCRIPTION
According to the issue below, adding a `create_before_destroy` lifecycle resource to all parent resources that touch a child resource is no longer required, so it is being removed from this module. In addition, the security group rules for the bastion EC2 instance is being removed so that the module user can set more granular rules on their own.

Lastly, there are two new top level attributes for `project` and `environment`. These values are passed through to resources that support AWS tags.

See: https://github.com/hashicorp/terraform/issues/2359

---

**Testing**

The easiest way to test this is probably to test https://github.com/azavea/pwd-stormdrain-marking/pull/39.