### PR TITLE
Add support for NAT Gateway Elastic IP outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ module "vpc" {
 - `bastion_hostname` - Public DNS name for bastion instance
 - `bastion_security_group_id` - Security group ID tied to bastion instance
 - `cidr_block` - The CIDR block associated with the VPC
+- `nat_gateway_ips` - List of Elastic IPs associated with NAT gateways

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,3 +21,7 @@ output "bastion_security_group_id" {
 output "cidr_block" {
   value = "${var.cidr_block}"
 }
+
+output "nat_gateway_ips" {
+  value = ["${aws_eip.nat.*.public_ip}"]
+}


### PR DESCRIPTION
Add a way to emit the list Elastic IPs bound to NAT Gateways created within the module so that consumers can reference them when necessary.

