### PR TITLE
Use standalone route resources to associate with route table

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,11 +23,6 @@ resource "aws_route_table" "private" {
 
   vpc_id = "${aws_vpc.default.id}"
 
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = "${element(aws_nat_gateway.default.*.id, count.index)}"
-  }
-
   tags {
     Name        = "PrivateRouteTable"
     Project     = "${var.project}"
@@ -35,19 +30,28 @@ resource "aws_route_table" "private" {
   }
 }
 
+resource "aws_route" "private" {
+  count = "${length(var.private_subnet_cidr_blocks)}"
+
+  route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = "${element(aws_nat_gateway.default.*.id, count.index)}"
+}
+
 resource "aws_route_table" "public" {
   vpc_id = "${aws_vpc.default.id}"
-
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.default.id}"
-  }
 
   tags {
     Name        = "PublicRouteTable"
     Project     = "${var.project}"
     Environment = "${var.environment}"
   }
+}
+
+resource "aws_route" "public" {
+  route_table_id         = "${aws_route_table.public.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${aws_internet_gateway.default.id}"
 }
 
 resource "aws_subnet" "private" {


### PR DESCRIPTION
When associating a route table with a route, use the standalone route resource instead of the in-line `route` attributes of the route table resource for greater flexibility. This allows future route associations to be made against the route table resource without route conflicts.