### PR TITLE
Give option to add bastion to multiple security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ module "vpc" {
 - `bastion_security_group_id` - Security group ID tied to bastion instance
 - `cidr_block` - The CIDR block associated with the VPC
 - `nat_gateway_ips` - List of Elastic IPs associated with NAT gateways
+- `bastion_network_interface_id` - ID of the Bastion instance's primary network interface

--- a/main.tf
+++ b/main.tf
@@ -136,13 +136,17 @@ resource "aws_security_group" "bastion" {
   }
 }
 
+resource "aws_network_interface_sg_attachment" "bastion" {
+  security_group_id = "${aws_security_group.bastion.id}"
+  network_interface = "${aws_instance.bastion.primary_network_interface}"
+}
+
 resource "aws_instance" "bastion" {
   ami                         = "${var.bastion_ami}"
   availability_zone           = "${element(var.availability_zones, 0)}"
   instance_type               = "${var.bastion_instance_type}"
   key_name                    = "${var.key_name}"
   monitoring                  = true
-  vpc_security_group_ids      = ["${aws_security_group.bastion.id}"]
   subnet_id                   = "${element(aws_subnet.public.*.id, 0)}"
   associate_public_ip_address = true
 

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ resource "aws_security_group" "bastion" {
 }
 
 resource "aws_network_interface_sg_attachment" "bastion" {
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id    = "${aws_security_group.bastion.id}"
   network_interface_id = "${aws_instance.bastion.primary_network_interface_id}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ resource "aws_security_group" "bastion" {
 
 resource "aws_network_interface_sg_attachment" "bastion" {
   security_group_id = "${aws_security_group.bastion.id}"
-  network_interface_id = "${aws_instance.bastion.primary_network_interface}"
+  network_interface_id = "${aws_instance.bastion.primary_network_interface_id}"
 }
 
 resource "aws_instance" "bastion" {

--- a/main.tf
+++ b/main.tf
@@ -138,7 +138,7 @@ resource "aws_security_group" "bastion" {
 
 resource "aws_network_interface_sg_attachment" "bastion" {
   security_group_id = "${aws_security_group.bastion.id}"
-  network_interface = "${aws_instance.bastion.primary_network_interface}"
+  network_interface_id = "${aws_instance.bastion.primary_network_interface}"
 }
 
 resource "aws_instance" "bastion" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,7 +18,7 @@ output "bastion_security_group_id" {
   value = "${aws_security_group.bastion.id}"
 }
 
-output "bastion_network_interface" {
+output "bastion_network_interface_id" {
   value = "${aws_instance.bastion.primary_network_interface_id}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,7 +19,7 @@ output "bastion_security_group_id" {
 }
 
 output "bastion_network_interface" {
-  value = "${aws_instance.bastion.primary_network_interface}"
+  value = "${aws_instance.bastion.primary_network_interface_id}"
 }
 
 output "cidr_block" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,10 @@ output "bastion_security_group_id" {
   value = "${aws_security_group.bastion.id}"
 }
 
+output "bastion_network_interface" {
+  value = "${aws_instance.bastion.primary_network_interface}"
+}
+
 output "cidr_block" {
   value = "${var.cidr_block}"
 }


### PR DESCRIPTION
Currently, when we create the bastion instance, it's attached to a single inline security group. Users are unable to add the bastion to any additional security groups, which implicitly puts an upper bound of 40 security group rules on the instance. This PR changes the method of attachment to `aws_network_interface_sg_attachment` and outputs `bastion_network_interface_id` so that users can attach the bastion to multiple security groups.

# Testing
See publicmapping/districtbuilder#529