### PR TITLE
Document setting up security rules for the bastion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ A Terraform module to create an Amazon Web Services (AWS) Virtual Private Cloud 
 
 This module creates a VPC alongside a variety of related resources, including:
 
-    - Two public and private subnets
-    - Two public and private route tables
-    - Two Elastic IPs
-    - Two Network Interfaces
-    - Two NAT Gateways
-    - An Internet Gateway
-    - A VPC Endpoint
-    - A bastion EC2 instance
+- Two public and private subnets
+- Two public and private route tables
+- Two Elastic IPs
+- Two Network Interfaces
+- Two NAT Gateways
+- An Internet Gateway
+- A VPC Endpoint
+- A bastion EC2 instance
 
 Example usage:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,20 @@ A Terraform module to create an Amazon Web Services (AWS) Virtual Private Cloud 
 
 ## Usage
 
-```javascript
+This module creates a VPC alongside a variety of related resources, including:
+
+    - Two public and private subnets
+    - Two public and private route tables
+    - Two Elastic IPs
+    - Two Network Interfaces
+    - Two NAT Gateways
+    - An Internet Gateway
+    - A VPC Endpoint
+    - A bastion EC2 instance
+
+Example usage:
+
+```hcl
 module "vpc" {
   source = "github.com/azavea/terraform-aws-vpc"
 
@@ -12,7 +25,6 @@ module "vpc" {
   region = "us-east-1"
   key_name = "hector"
   cidr_block = "10.0.0.0/16"
-  external_access_cidr_block = "0.0.0.0/0"
   private_subnet_cidr_blocks = ["10.0.1.0/24", "10.0.3.0/24"]
   public_subnet_cidr_blocks = ["10.0.0.0/24", "10.0.2.0/24"]
   availability_zones = ["us-east-1a", "us-east-1b"]
@@ -24,6 +36,48 @@ module "vpc" {
 }
 ```
 
+### Configuring security rules
+
+By default, this module adds no security rules to the bastion instance, meaning
+that all traffic will be blocked.
+
+In order to configure security rules for the bastion, use the
+`bastion_security_group_id` output. For example:
+
+```hcl
+resource "aws_security_group_rule" "ssh_ingress" {
+  security_group_id = "${module.vpc.bastion_security_group_id}"
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.bastion_inbound_cidr_block}"]
+}
+```
+
+There is a limit to the number of rules you can add to a security group. If you
+have exceeded this limit, you can add additional security groups to the bastion
+using the `bastion_network_interface_id` output and an
+`aws_network_interface_sg_attachment` resource. For example:
+
+```hcl
+resource "aws_security_group" "ssh_ingress" {
+  vpc_id = "${module.vpc.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${var.bastion_inbound_cidr_block}"]
+  }
+}
+
+resource "aws_network_interface_sg_attachment" "sg_attachment" {
+  security_group_id    = "${aws_security_group.ssh_ingress.id}"
+  network_interface_id = "${module.vpc.bastion_network_interface_id}"
+}
+```
+
 ## Variables
 
 - `name` - Name of the VPC (default: `Default`)
@@ -32,8 +86,6 @@ module "vpc" {
 - `region` - Region of the VPC (default: `us-east-1`)
 - `key_name` - EC2 Key pair name
 - `cidr_block` - CIDR block to allocate for the VPC (default: `10.0.0.0/16`)
-- `external_access_cidr_block` - CIDR block for inbound clients to VPC bastion
-  (default: `0.0.0.0/0`)
 - `public_subnet_cidr_blocks` - List of public subnet CIDR blocks (default: `["10.0.0.0/24","10.0.2.0/24"]`)
 - `private_subnet_cidr_blocks` - List of private subnet CIDR blocks (default: `["10.0.1.0/24", "10.0.3.0/24"]`)
 - `availability_zones` - List of availability zones (default: `["us-east-1a", "us-east-1b"]`)

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A Terraform module to create an Amazon Web Services (AWS) Virtual Private Cloud 
 
 This module creates a VPC alongside a variety of related resources, including:
 
-- Two public and private subnets
-- Two public and private route tables
-- Two Elastic IPs
-- Two Network Interfaces
-- Two NAT Gateways
+- Public and private subnets
+- Public and private route tables
+- Elastic IPs
+- Network Interfaces
+- NAT Gateways
 - An Internet Gateway
 - A VPC Endpoint
 - A bastion EC2 instance

--- a/main.tf
+++ b/main.tf
@@ -134,13 +134,6 @@ resource "aws_security_group" "bastion" {
     Project     = "${var.project}"
     Environment = "${var.environment}"
   }
-
-  ingress {
-    from        = 22
-    to          = 22
-    protocol    = "tcp"
-    cidr_blocks = ["${var.external_access_cidr_block}"]
-  }
 }
 
 resource "aws_network_interface_sg_attachment" "bastion" {

--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,13 @@ resource "aws_security_group" "bastion" {
     Project     = "${var.project}"
     Environment = "${var.environment}"
   }
+
+  ingress {
+    from        = 22
+    to          = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${var.external_access_cidr_block}"]
+  }
 }
 
 resource "aws_network_interface_sg_attachment" "bastion" {

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,6 @@ variable "cidr_block" {
   default = "10.0.0.0/16"
 }
 
-variable "external_access_cidr_block" {
-  default = "0.0.0.0/0"
-}
-
 variable "public_subnet_cidr_blocks" {
   type    = "list"
   default = ["10.0.0.0/24", "10.0.2.0/24"]


### PR DESCRIPTION
# Overview

The `README` indicates that the value of the variable `external_access_cidr_block` will determine which clients can access the bastion, but the configuration doesn't actually set any inbound rules for the bastion, so no clients will be able to access the bastion no matter how the variable is set (#18). 

~This PR adds an ingress rule to the bastion security group resource, allowing inbound SSH traffic from the CIDR block identified by `external_access_cidr_block`.~

This PR updates the `README` to remove references to the deprecated `external_access_cidr_block` variable, and adds a section on using the module outputs to configure security groups.

## Testing instructions

If you'd like to confirm that the recommended code in the documentation actually works, you can use the [`terraform-config` branch of the `ahoy` breakable toy project](https://github.com/azavea/ahoy/tree/feature/jcochrane/terraform-config).

1. Create a local file `./deployment/terraform/terraform.tfvars` with the following dummy values (replace the IP address and SSH public key with values that you can use to confirm SSH access works later on):

```
postgres_db = "bar"
postgres_host = "baz"
postgres_user = "foo"
postgres_password = ""
django_secret_key = "foobarbaz"
django_allowed_hosts = "localhost"
aws_account_id = "foo"
bastion_inbound_cidr_block = "<your-ip-address-here>"
aws_key_pair_public_key = "<your-public-key-here>"
```

2. If not yet provisioned, provision the VM: `./scripts/setup`
3. SSH into the VM: `vagrant ssh`
5. Run the Terraform container: `docker-compose -f docker-compose.ci.yml run --rm terraform`
6. Set the AWS profile you'd like to use: `export AWS_PROFILE=<your-profile>`
7. Initialize Terraform: `cd ./deployment/terraform && terraform init`
8. Generate a deployment plan: `terraform plan -out terraform.tfplan`
9. Run the plan: `terraform apply terraform.tfplan`
10. Use the output hostname to test inbound SSH: `ssh -i /path/to/key ec2-user@<bastion-dns>`
11. If you'd like, log into the relevant AWS console to confirm that the security groups look good

## Related issues

Closes #18.