### PR TITLE
Add bastion_ebs_optimized variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ module "vpc" {
   private_subnet_cidr_blocks = ["10.0.1.0/24", "10.0.3.0/24"]
   public_subnet_cidr_blocks = ["10.0.0.0/24", "10.0.2.0/24"]
   availability_zones = ["us-east-1a", "us-east-1b"]
-  bastion_ami = "ami-ff02509a"
-  bastion_instance_type = "t2.micro"
+  bastion_ami = "ami-6869aa05"
+  bastion_instance_type = "t3.micro"
 
   project = "Something"
   environment = "Staging"
@@ -90,7 +90,8 @@ resource "aws_network_interface_sg_attachment" "sg_attachment" {
 - `private_subnet_cidr_blocks` - List of private subnet CIDR blocks (default: `["10.0.1.0/24", "10.0.3.0/24"]`)
 - `availability_zones` - List of availability zones (default: `["us-east-1a", "us-east-1b"]`)
 - `bastion_ami` - Bastion Amazon Machine Image (AMI) ID
-- `bastion_instance_type` - Instance type for bastion instance (default: `t2.micro`))
+- `bastion_ebs_optimized` - If true, the bastion instance will be EBS-optimized (default: `true`)
+- `bastion_instance_type` - Instance type for bastion instance (default: `t3.micro`)
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ resource "aws_network_interface_sg_attachment" "sg_attachment" {
 - `private_subnet_cidr_blocks` - List of private subnet CIDR blocks (default: `["10.0.1.0/24", "10.0.3.0/24"]`)
 - `availability_zones` - List of availability zones (default: `["us-east-1a", "us-east-1b"]`)
 - `bastion_ami` - Bastion Amazon Machine Image (AMI) ID
-- `bastion_ebs_optimized` - If true, the bastion instance will be EBS-optimized (default: `true`)
-- `bastion_instance_type` - Instance type for bastion instance (default: `t3.micro`)
+- `bastion_ebs_optimized` - If true, the bastion instance will be EBS-optimized (default: `false`)
+- `bastion_instance_type` - Instance type for bastion instance (default: `t2.micro`)
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ module "vpc" {
   public_subnet_cidr_blocks = ["10.0.0.0/24", "10.0.2.0/24"]
   availability_zones = ["us-east-1a", "us-east-1b"]
   bastion_ami = "ami-6869aa05"
+  bastion_ebs_optimized = true
   bastion_instance_type = "t3.micro"
 
   project = "Something"

--- a/main.tf
+++ b/main.tf
@@ -144,6 +144,7 @@ resource "aws_network_interface_sg_attachment" "bastion" {
 resource "aws_instance" "bastion" {
   ami                         = "${var.bastion_ami}"
   availability_zone           = "${element(var.availability_zones, 0)}"
+  ebs_optimized               = "${var.bastion_ebs_optimized}"
   instance_type               = "${var.bastion_instance_type}"
   key_name                    = "${var.key_name}"
   monitoring                  = true

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,10 @@ variable "availability_zones" {
 
 variable "bastion_ami" {}
 
+variable "bastion_ebs_optimized" {
+  default = true
+}
+
 variable "bastion_instance_type" {
-  default = "t2.micro"
+  default = "t3.micro"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -38,9 +38,9 @@ variable "availability_zones" {
 variable "bastion_ami" {}
 
 variable "bastion_ebs_optimized" {
-  default = true
+  default = false
 }
 
 variable "bastion_instance_type" {
-  default = "t3.micro"
+  default = "t2.micro"
 }


### PR DESCRIPTION
## Overview

This PR adds a `bastion_ebs_optimized` variable to support T3 instances, which are EBS-optimized by default.

When migrating Raster Foundry to use T3 instances, I ran into an issue where Terraform wanted to destroy the Bastion instance and set the EBS-optimized flag to `false`:

```bash
-/+ module.vpc.aws_instance.bastion (new resource required)
      id:                               "i-0c73b999b332ed26d" => <computed> (forces new resource)
      ami:                              "ami-6869aa05" => "ami-6869aa05"
      arn:                              "arn:aws:ec2:us-east-1:615874746523:instance/i-0c73b999b332ed26d" => <computed>
      associate_public_ip_address:      "true" => "true"
      availability_zone:                "us-east-1c" => "us-east-1c"
      cpu_core_count:                   "1" => <computed>
      cpu_threads_per_core:             "2" => <computed>
      ebs_block_device.#:               "0" => <computed>
      ebs_optimized:                    "true" => "false" (forces new resource)
      ephemeral_block_device.#:         "0" => <computed>
      get_password_data:                "false" => "false"
      host_id:                          "" => <computed>
      instance_state:                   "running" => <computed>
      instance_type:                    "t3.nano" => "t3.nano"
...
```

## Testing Instructions

See: https://github.com/azavea/raster-foundry-deployment/pull/211