### PR TITLE
Upgrade module to support Terraform 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.0.0
+
+- Add support for Terraform 0.12.
+- Update the default for `bastion_instance_type` to `t3.nano`.
+- Add a `tags` variable.
+- Add continuous integration support via CircleCI.
+
 ## 5.0.1
 
 - `element()` -> `listvar[idx]`

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ resource "aws_network_interface_sg_attachment" "sg_attachment" {
 - `bastion_ami` - Bastion Amazon Machine Image (AMI) ID
 - `bastion_ebs_optimized` - If true, the bastion instance will be EBS-optimized (default: `false`)
 - `bastion_instance_type` - Instance type for bastion instance (default: `t3.nano`)
+- `tags` - Extra tags to attach to the VPC resources (default: `{}`)
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ In order to configure security rules for the bastion, use the
 
 ```hcl
 resource "aws_security_group_rule" "ssh_ingress" {
-  security_group_id = "${module.vpc.bastion_security_group_id}"
+  security_group_id = module.vpc.bastion_security_group_id
   type              = "ingress"
   from_port         = 22
   to_port           = 22
   protocol          = "tcp"
-  cidr_blocks       = ["${var.bastion_inbound_cidr_block}"]
+  cidr_blocks       = [var.bastion_inbound_cidr_block]
 }
 ```
 
@@ -65,19 +65,19 @@ using the `bastion_network_interface_id` output and an
 
 ```hcl
 resource "aws_security_group" "ssh_ingress" {
-  vpc_id = "${module.vpc.id}"
+  vpc_id = module.vpc.id
 
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["${var.bastion_inbound_cidr_block}"]
+    cidr_blocks = [var.bastion_inbound_cidr_block]
   }
 }
 
 resource "aws_network_interface_sg_attachment" "sg_attachment" {
-  security_group_id    = "${aws_security_group.ssh_ingress.id}"
-  network_interface_id = "${module.vpc.bastion_network_interface_id}"
+  security_group_id    = aws_security_group.ssh_ingress.id
+  network_interface_id = module.vpc.bastion_network_interface_id
 }
 ```
 
@@ -104,6 +104,6 @@ resource "aws_network_interface_sg_attachment" "sg_attachment" {
 - `private_subnets_ids` - List of private subnet IDs
 - `bastion_hostname` - Public DNS name for bastion instance
 - `bastion_security_group_id` - Security group ID tied to bastion instance
-- `bastion_network_interface_id` - ENI ID of the Bastion instance's primary network interface
+- `bastion_network_interface_id` - Elastic Network Interface (ENI) ID of the Bastion instance's primary network interface
 - `cidr_block` - The CIDR block associated with the VPC
 - `nat_gateway_ips` - List of Elastic IPs associated with NAT gateways

--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ resource "aws_network_interface_sg_attachment" "sg_attachment" {
 - `project` - Name of project this VPC is meant to house (default: `Unknown`)
 - `environment` - Name of environment this VPC is targeting (default: `Unknown`)
 - `region` - Region of the VPC (default: `us-east-1`)
-- `key_name` - EC2 Key pair name
-- `cidr_block` - CIDR block to allocate for the VPC (default: `10.0.0.0/16`)
+- `key_name` - EC2 Key pair name for the bastion
+- `cidr_block` - CIDR block for the VPC (default: `10.0.0.0/16`)
 - `public_subnet_cidr_blocks` - List of public subnet CIDR blocks (default: `["10.0.0.0/24","10.0.2.0/24"]`)
 - `private_subnet_cidr_blocks` - List of private subnet CIDR blocks (default: `["10.0.1.0/24", "10.0.3.0/24"]`)
 - `availability_zones` - List of availability zones (default: `["us-east-1a", "us-east-1b"]`)
 - `bastion_ami` - Bastion Amazon Machine Image (AMI) ID
 - `bastion_ebs_optimized` - If true, the bastion instance will be EBS-optimized (default: `false`)
-- `bastion_instance_type` - Instance type for bastion instance (default: `t2.micro`)
+- `bastion_instance_type` - Instance type for bastion instance (default: `t3.nano`)
 
 ## Outputs
 
@@ -103,6 +103,6 @@ resource "aws_network_interface_sg_attachment" "sg_attachment" {
 - `private_subnets_ids` - List of private subnet IDs
 - `bastion_hostname` - Public DNS name for bastion instance
 - `bastion_security_group_id` - Security group ID tied to bastion instance
+- `bastion_network_interface_id` - ENI ID of the Bastion instance's primary network interface
 - `cidr_block` - The CIDR block associated with the VPC
 - `nat_gateway_ips` - List of Elastic IPs associated with NAT gateways
-- `bastion_network_interface_id` - ID of the Bastion instance's primary network interface

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,15 @@ resource "aws_vpc" "default" {
 
 resource "aws_internet_gateway" "default" {
   vpc_id = aws_vpc.default.id
+
+  tags = merge(
+    {
+      Name        = "gwInternet",
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags
+  )
 }
 
 resource "aws_route_table" "private" {

--- a/main.tf
+++ b/main.tf
@@ -1,159 +1,198 @@
 #
 # VPC resources
 #
-
 resource "aws_vpc" "default" {
-  cidr_block           = "${var.cidr_block}"
+  cidr_block           = var.cidr_block
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags {
-    Name        = "${var.name}"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
-  }
+  tags = merge(
+    {
+      Name        = var.name,
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags
+  )
 }
 
 resource "aws_internet_gateway" "default" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 }
 
 resource "aws_route_table" "private" {
-  count = "${length(var.private_subnet_cidr_blocks)}"
+  count = length(var.private_subnet_cidr_blocks)
 
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
-  tags {
-    Name        = "PrivateRouteTable"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
-  }
+  tags = merge(
+    {
+      Name        = "PrivateRouteTable",
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags
+  )
 }
 
 resource "aws_route" "private" {
-  count = "${length(var.private_subnet_cidr_blocks)}"
+  count = length(var.private_subnet_cidr_blocks)
 
-  route_table_id         = "${aws_route_table.private.*.id[count.index]}"
+  route_table_id         = aws_route_table.private[count.index].id
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${aws_nat_gateway.default.*.id[count.index]}"
+  nat_gateway_id         = aws_nat_gateway.default[count.index].id
 }
 
 resource "aws_route_table" "public" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
-  tags {
-    Name        = "PublicRouteTable"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
-  }
+  tags = merge(
+    {
+      Name        = "PublicRouteTable",
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags
+  )
 }
 
 resource "aws_route" "public" {
-  route_table_id         = "${aws_route_table.public.id}"
+  route_table_id         = aws_route_table.public.id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.default.id}"
+  gateway_id             = aws_internet_gateway.default.id
 }
 
 resource "aws_subnet" "private" {
-  count = "${length(var.private_subnet_cidr_blocks)}"
+  count = length(var.private_subnet_cidr_blocks)
 
-  vpc_id            = "${aws_vpc.default.id}"
-  cidr_block        = "${var.private_subnet_cidr_blocks[count.index]}"
-  availability_zone = "${var.availability_zones[count.index]}"
+  vpc_id            = aws_vpc.default.id
+  cidr_block        = var.private_subnet_cidr_blocks[count.index]
+  availability_zone = var.availability_zones[count.index]
 
-  tags {
-    Name        = "PrivateSubnet"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
-  }
+  tags = merge(
+    {
+      Name        = "PrivateSubnet",
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags
+  )
 }
 
 resource "aws_subnet" "public" {
-  count = "${length(var.public_subnet_cidr_blocks)}"
+  count = length(var.public_subnet_cidr_blocks)
 
-  vpc_id                  = "${aws_vpc.default.id}"
-  cidr_block              = "${var.public_subnet_cidr_blocks[count.index]}"
-  availability_zone       = "${var.availability_zones[count.index]}"
+  vpc_id                  = aws_vpc.default.id
+  cidr_block              = var.public_subnet_cidr_blocks[count.index]
+  availability_zone       = var.availability_zones[count.index]
   map_public_ip_on_launch = true
 
-  tags {
-    Name        = "PublicSubnet"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
-  }
+  tags = merge(
+    {
+      Name        = "PublicSubnet",
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags
+  )
 }
 
 resource "aws_route_table_association" "private" {
-  count = "${length(var.private_subnet_cidr_blocks)}"
+  count = length(var.private_subnet_cidr_blocks)
 
-  subnet_id      = "${aws_subnet.private.*.id[count.index]}"
-  route_table_id = "${aws_route_table.private.*.id[count.index]}"
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
 }
 
 resource "aws_route_table_association" "public" {
-  count = "${length(var.public_subnet_cidr_blocks)}"
+  count = length(var.public_subnet_cidr_blocks)
 
-  subnet_id      = "${aws_subnet.public.*.id[count.index]}"
-  route_table_id = "${aws_route_table.public.id}"
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
 }
 
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id          = "${aws_vpc.default.id}"
-  service_name    = "com.amazonaws.${var.region}.s3"
-  route_table_ids = ["${aws_route_table.public.id}", "${aws_route_table.private.*.id}"]
+  vpc_id       = aws_vpc.default.id
+  service_name = "com.amazonaws.${var.region}.s3"
+  route_table_ids = flatten([
+    aws_route_table.public.id,
+    aws_route_table.private.*.id
+  ])
+
+  tags = merge(
+    {
+      Name        = "endpointS3",
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags
+  )
 }
 
 #
 # NAT resources
 #
-
 resource "aws_eip" "nat" {
-  count = "${length(var.public_subnet_cidr_blocks)}"
+  count = length(var.public_subnet_cidr_blocks)
 
   vpc = true
 }
 
 resource "aws_nat_gateway" "default" {
-  count = "${length(var.public_subnet_cidr_blocks)}"
-
-  allocation_id = "${aws_eip.nat.*.id[count.index]}"
-  subnet_id     = "${aws_subnet.public.*.id[count.index]}"
-
   depends_on = ["aws_internet_gateway.default"]
+
+  count = length(var.public_subnet_cidr_blocks)
+
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(
+    {
+      Name        = "gwNAT",
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags
+  )
 }
 
 #
 # Bastion resources
 #
-
 resource "aws_security_group" "bastion" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
 
-  tags {
-    Name        = "sgBastion"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
-  }
+  tags = merge(
+    {
+      Name        = "sgBastion",
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags
+  )
 }
 
 resource "aws_network_interface_sg_attachment" "bastion" {
-  security_group_id    = "${aws_security_group.bastion.id}"
-  network_interface_id = "${aws_instance.bastion.primary_network_interface_id}"
+  security_group_id    = aws_security_group.bastion.id
+  network_interface_id = aws_instance.bastion.primary_network_interface_id
 }
 
 resource "aws_instance" "bastion" {
-  ami                         = "${var.bastion_ami}"
-  availability_zone           = "${var.availability_zones[0]}"
-  ebs_optimized               = "${var.bastion_ebs_optimized}"
-  instance_type               = "${var.bastion_instance_type}"
-  key_name                    = "${var.key_name}"
+  ami                         = var.bastion_ami
+  availability_zone           = var.availability_zones[0]
+  ebs_optimized               = var.bastion_ebs_optimized
+  instance_type               = var.bastion_instance_type
+  key_name                    = var.key_name
   monitoring                  = true
-  subnet_id                   = "${aws_subnet.public.*.id[0]}"
+  subnet_id                   = aws_subnet.public[0].id
   associate_public_ip_address = true
 
-  tags {
-    Name        = "Bastion"
-    Project     = "${var.project}"
-    Environment = "${var.environment}"
-  }
+  tags = merge(
+    {
+      Name        = "Bastion",
+      Project     = var.project,
+      Environment = var.environment
+    },
+    var.tags
+  )
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,31 +1,39 @@
 output "id" {
-  value = "${aws_vpc.default.id}"
+  value       = aws_vpc.default.id
+  description = "VPC ID."
 }
 
 output "public_subnet_ids" {
-  value = ["${aws_subnet.public.*.id}"]
+  value       = aws_subnet.public.*.id
+  description = "List of public subnet IDs."
 }
 
 output "private_subnet_ids" {
-  value = ["${aws_subnet.private.*.id}"]
+  value       = aws_subnet.private.*.id
+  description = "List of private subnet IDs."
 }
 
 output "bastion_hostname" {
-  value = "${aws_instance.bastion.public_dns}"
+  value       = aws_instance.bastion.public_dns
+  description = "Public DNS name for bastion instance."
 }
 
 output "bastion_security_group_id" {
-  value = "${aws_security_group.bastion.id}"
+  value       = aws_security_group.bastion.id
+  description = "Security group ID tied to bastion instance."
 }
 
 output "bastion_network_interface_id" {
-  value = "${aws_instance.bastion.primary_network_interface_id}"
+  value       = aws_instance.bastion.primary_network_interface_id
+  description = "ENI ID of the Bastion instance's primary network interface."
 }
 
 output "cidr_block" {
-  value = "${var.cidr_block}"
+  value       = var.cidr_block
+  description = "The CIDR block associated with the VPC."
 }
 
 output "nat_gateway_ips" {
-  value = ["${aws_eip.nat.*.public_ip}"]
+  value       = aws_eip.nat.*.public_ip
+  description = "List of Elastic IPs associated with NAT gateways."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,39 +1,39 @@
 output "id" {
   value       = aws_vpc.default.id
-  description = "VPC ID."
+  description = "VPC ID"
 }
 
 output "public_subnet_ids" {
   value       = aws_subnet.public.*.id
-  description = "List of public subnet IDs."
+  description = "List of public subnet IDs"
 }
 
 output "private_subnet_ids" {
   value       = aws_subnet.private.*.id
-  description = "List of private subnet IDs."
+  description = "List of private subnet IDs"
 }
 
 output "bastion_hostname" {
   value       = aws_instance.bastion.public_dns
-  description = "Public DNS name for bastion instance."
+  description = "Public DNS name for bastion instance"
 }
 
 output "bastion_security_group_id" {
   value       = aws_security_group.bastion.id
-  description = "Security group ID tied to bastion instance."
+  description = "Security group ID tied to bastion instance"
 }
 
 output "bastion_network_interface_id" {
   value       = aws_instance.bastion.primary_network_interface_id
-  description = "ENI ID of the Bastion instance's primary network interface."
+  description = "ENI ID of the Bastion instance's primary network interface"
 }
 
 output "cidr_block" {
   value       = var.cidr_block
-  description = "The CIDR block associated with the VPC."
+  description = "The CIDR block associated with the VPC"
 }
 
 output "nat_gateway_ips" {
   value       = aws_eip.nat.*.public_ip
-  description = "List of Elastic IPs associated with NAT gateways."
+  description = "List of Elastic IPs associated with NAT gateways"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,7 +25,7 @@ output "bastion_security_group_id" {
 
 output "bastion_network_interface_id" {
   value       = aws_instance.bastion.primary_network_interface_id
-  description = "ENI ID of the Bastion instance's primary network interface"
+  description = "Elastic Network Interface (ENI) ID of the Bastion instance's primary network interface"
 }
 
 output "cidr_block" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,46 +1,67 @@
 variable "name" {
-  default = "Default"
+  default     = "Default"
+  type        = string
+  description = "Name of the VPC."
 }
 
 variable "project" {
-  default = "Unknown"
+  type        = string
+  description = "Name of project this VPC is meant to house."
 }
 
 variable "environment" {
-  default = "Unknown"
+  type        = string
+  description = "Name of environment this VPC is targeting"
 }
 
 variable "region" {
-  default = "us-east-1"
+  default     = "us-east-1"
+  type        = string
+  description = "Region of the VPC."
 }
 
-variable "key_name" {}
+variable "key_name" {
+  type        = string
+  description = "EC2 Key pair name for the bastion."
+}
 
 variable "cidr_block" {
-  default = "10.0.0.0/16"
+  default     = "10.0.0.0/16"
+  type        = string
+  description = "CIDR block for the VPC."
 }
 
 variable "public_subnet_cidr_blocks" {
-  type    = "list"
-  default = ["10.0.0.0/24", "10.0.2.0/24"]
+  default     = ["10.0.0.0/24", "10.0.2.0/24"]
+  type        = list
+  description = "List of public subnet CIDR blocks."
 }
 
 variable "private_subnet_cidr_blocks" {
-  type    = "list"
-  default = ["10.0.1.0/24", "10.0.3.0/24"]
+  default     = ["10.0.1.0/24", "10.0.3.0/24"]
+  type        = list
+  description = "List of private subnet CIDR blocks"
 }
 
 variable "availability_zones" {
-  type    = "list"
-  default = ["us-east-1a", "us-east-1b"]
+  default     = ["us-east-1a", "us-east-1b"]
+  type        = list
+  description = "List of availability zones."
 }
 
-variable "bastion_ami" {}
+variable "bastion_ami" {
+  type        = string
+  description = "Bastion Amazon Machine Image (AMI) ID."
+}
 
 variable "bastion_ebs_optimized" {
-  default = false
+  default     = false
+  type        = bool
+  description = "If true, the bastion instance will be EBS-optimized."
 }
 
 variable "bastion_instance_type" {
-  default = "t2.micro"
+  default     = "t3.nano"
+  type        = string
+  description = "Instance type for bastion instance."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,12 @@
 variable "name" {
   default     = "Default"
   type        = string
-  description = "Name of the VPC."
+  description = "Name of the VPC"
 }
 
 variable "project" {
   type        = string
-  description = "Name of project this VPC is meant to house."
+  description = "Name of project this VPC is meant to house"
 }
 
 variable "environment" {
@@ -17,24 +17,24 @@ variable "environment" {
 variable "region" {
   default     = "us-east-1"
   type        = string
-  description = "Region of the VPC."
+  description = "Region of the VPC"
 }
 
 variable "key_name" {
   type        = string
-  description = "EC2 Key pair name for the bastion."
+  description = "EC2 Key pair name for the bastion"
 }
 
 variable "cidr_block" {
   default     = "10.0.0.0/16"
   type        = string
-  description = "CIDR block for the VPC."
+  description = "CIDR block for the VPC"
 }
 
 variable "public_subnet_cidr_blocks" {
   default     = ["10.0.0.0/24", "10.0.2.0/24"]
   type        = list
-  description = "List of public subnet CIDR blocks."
+  description = "List of public subnet CIDR blocks"
 }
 
 variable "private_subnet_cidr_blocks" {
@@ -46,22 +46,28 @@ variable "private_subnet_cidr_blocks" {
 variable "availability_zones" {
   default     = ["us-east-1a", "us-east-1b"]
   type        = list
-  description = "List of availability zones."
+  description = "List of availability zones"
 }
 
 variable "bastion_ami" {
   type        = string
-  description = "Bastion Amazon Machine Image (AMI) ID."
+  description = "Bastion Amazon Machine Image (AMI) ID"
 }
 
 variable "bastion_ebs_optimized" {
   default     = false
   type        = bool
-  description = "If true, the bastion instance will be EBS-optimized."
+  description = "If true, the bastion instance will be EBS-optimized"
 }
 
 variable "bastion_instance_type" {
   default     = "t3.nano"
   type        = string
-  description = "Instance type for bastion instance."
+  description = "Instance type for bastion instance"
+}
+
+variable "tags" {
+  default     = {}
+  type        = map(string)
+  description = "Extra tags to attach to the VPC resources"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    aws = ">= 2.33.0"
+  }
+}


### PR DESCRIPTION
Following the instructions outlined in the [Terraform documentation](https://www.terraform.io/upgrade-guides/0-12.html), update the module's configuration to support Terraform 0.12. Despite containing minor changes, this is expected to cause a major version bump, because the changes are not backwards compatible.

Fixes https://github.com/azavea/terraform-aws-vpc/issues/23

---

**Testing**

Please use https://github.com/azavea/dinghy/pull/17 to test this PR.