### PR TITLE
Fix deprecated quoted depends_on reference

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -148,7 +148,7 @@ resource "aws_eip" "nat" {
 }
 
 resource "aws_nat_gateway" "default" {
-  depends_on = ["aws_internet_gateway.default"]
+  depends_on = [aws_internet_gateway.default]
 
   count = length(var.public_subnet_cidr_blocks)
 


### PR DESCRIPTION
Quoted references to other resources was necessary in Terraform 0.11 and earlier, but is not deprecated in Terraform 0.12 and later. Quoted references can be removed in this module because it is pinned to a
minimum version of Terraform 0.12.

Fixes https://github.com/azavea/terraform-aws-vpc/issues/27

---

**Testing**

Please use https://github.com/azavea/noaa-flood-mapping/pull/42 to test these changes.